### PR TITLE
fix: dont panic inside implementation

### DIFF
--- a/macros/src/impls/try_from_multipart.rs
+++ b/macros/src/impls/try_from_multipart.rs
@@ -165,7 +165,7 @@ pub fn macro_impl(input: TokenStream) -> TokenStream {
                 #(#declarations)*
 
                 while let Some(__field__) = multipart.next_field().await? {
-                    let __field_name__ = __field__.name().unwrap().to_string();
+                    let __field_name__ = __field__.name().ok_or(axum_typed_multipart::TypedMultipartError::NamelessField)?.to_string();
                     #(#assignments) else *
                 }
 

--- a/src/typed_multipart_error.rs
+++ b/src/typed_multipart_error.rs
@@ -32,6 +32,9 @@ pub enum TypedMultipartError {
     #[error("field '{field_name}' is larger than {limit_bytes} bytes")]
     FieldTooLarge { field_name: String, limit_bytes: usize },
 
+    #[error("field with no name")]
+    NamelessField,
+
     #[error(transparent)]
     Other {
         #[from]
@@ -45,7 +48,8 @@ impl TypedMultipartError {
             | Self::MissingField { .. }
             | Self::WrongFieldType { .. }
             | Self::DuplicateField { .. }
-            | Self::UnknownField { .. } => StatusCode::BAD_REQUEST,
+            | Self::UnknownField { .. }
+            | Self::NamelessField => StatusCode::BAD_REQUEST,
             | Self::FieldTooLarge { .. } => StatusCode::PAYLOAD_TOO_LARGE,
             | Self::InvalidRequest { source } => source.status(),
             | Self::InvalidRequestBody { source } => source.status(),


### PR DESCRIPTION
As the PR title said. The reason for this is that I don't want my code to panic because of some macro implementation.

Todo

- [ ] Add test
- [ ] Better error (maybe?)