### PR TITLE
impl Deref and DerefMut for TypedMultipart and BaseMultipart

### DIFF
--- a/src/base_multipart.rs
+++ b/src/base_multipart.rs
@@ -105,7 +105,7 @@ mod tests {
     }
 
     #[test]
-    fn deref() {
+    fn test_deref() {
         #[derive(Debug, Clone, Eq, PartialEq)]
         struct Data {
             v0: String,

--- a/src/typed_multipart.rs
+++ b/src/typed_multipart.rs
@@ -96,7 +96,7 @@ mod tests {
     }
 
     #[test]
-    fn deref() {
+    fn test_deref() {
         #[derive(Debug, Clone, Eq, PartialEq)]
         struct Data {
             v0: String,


### PR DESCRIPTION
This PR implements `Deref` and `DerefMut` traits for `TypedMultipart` and `BaseMultipart`. This makes these types more ergonomic to use, allowing them to be dereferenced to the inner type.

```rust
struct Data {}
impl Data {
    pub fn modify(&mut self) {}
    pub fn read(&self) {}
}
let mut tm = TypedMultipart(Data {});
tm.modify();
tm.read();
```