### PR TITLE
Minimal utoipa example with file upload

### DIFF
--- a/examples/utoipa/Cargo.toml
+++ b/examples/utoipa/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+edition = "2021"
+name = "utoipa-example"
+
+[workspace]
+
+[dependencies]
+axum = { version = "0.7.7", features = ["multipart"] }
+axum_typed_multipart = { version = "0.0.0", path = "../.." }
+serde = "1.0.210"
+serde_json = "1.0.128"
+tempfile = "3.13.0"
+tokio = { version = "1.40.0", features = ["net", "rt-multi-thread"] }
+utoipa = "4.2.3"
+utoipa-rapidoc = { version = "4.0.0", features = ["axum"] }

--- a/examples/utoipa/Cargo.toml
+++ b/examples/utoipa/Cargo.toml
@@ -7,6 +7,7 @@ name = "utoipa-example"
 [dependencies]
 axum = { version = "0.7.7", features = ["multipart"] }
 axum_typed_multipart = { version = "0.0.0", path = "../.." }
+futures-core = "0.3.28"
 serde = "1.0.210"
 serde_json = "1.0.128"
 tempfile = "3.13.0"

--- a/examples/utoipa/src/main.rs
+++ b/examples/utoipa/src/main.rs
@@ -1,0 +1,71 @@
+use axum::{
+    body::Bytes,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::post,
+    Json, Router,
+};
+use axum_typed_multipart::{FieldData, TryFromMultipart, TypedMultipart};
+use serde::Serialize;
+use utoipa::{OpenApi, ToSchema};
+use utoipa_rapidoc::RapiDoc;
+
+#[derive(OpenApi)]
+#[openapi(paths(file_upload), components(schemas(FileUpload, Status)))]
+struct ApiDoc;
+
+#[derive(TryFromMultipart, ToSchema)]
+pub struct FileUpload {
+    /// User's name
+    #[schema(example = "John Doe")]
+    name: String,
+
+    /// File or files to upload
+    #[form_data(limit = "2MiB")]
+    #[schema(value_type = Vec<u8>)]
+    file: Vec<FieldData<Bytes>>,
+}
+
+#[derive(Debug, Default, Serialize, ToSchema)]
+pub struct Status {
+    /// Status
+    #[schema(example = "error")]
+    pub status: String,
+    /// What went wrong
+    #[schema(example = "Could not open file")]
+    pub error: Option<String>,
+}
+
+/// Upload a file
+///
+/// Accepts a user's name and a file
+#[utoipa::path(
+    post,
+    path = "/upload",
+    request_body(content_type = "multipart/form-data", content = FileUpload),
+    responses(
+        (status = 200, description = "File uploaded successfully", body = Status),
+    ),
+    tag = "Upload"
+)]
+async fn file_upload(
+    TypedMultipart(FileUpload { name, file }): TypedMultipart<FileUpload>,
+) -> Response {
+    println!("User's name: {name}");
+    for f in file.into_iter() {
+        println!("Filename: {:?}", f.metadata.file_name);
+    }
+    (StatusCode::OK, Json(Status { status: "ok".into(), error: None })).into_response()
+}
+
+#[tokio::main]
+async fn main() {
+    let app = Router::new()
+        .merge(RapiDoc::with_openapi("/api-docs/openapi2.json", ApiDoc::openapi()).path("/"))
+        .route("/upload", post(file_upload))
+        .into_make_service();
+
+    println!("Listening on http://0.0.0.0:3000");
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
+    axum::serve(listener, app).await.unwrap();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,6 +251,20 @@
 #![doc = include_str!("../examples/custom_error.rs")]
 //! ```
 //!
+//! ### Usage with utoipa
+//!
+//! If you would like to use `axum_typed_multipart` as part of a documented API then
+//! [`utoipa`](https://github.com/juhaku/utoipa) can provide a simple way to add documentation to
+//! an API and automatically generate `openapi.json` specifications. `axum_typed_multipart` can
+//! be used in conjunction with `utoipa` easily. An example implementation is included.
+//!
+//! Note: File uploads in `utoipa` require a type of `Vec<u8>` which is incompatible with
+//! `axum_typed_multipart` which uses either `Bytes` or [tempfile::NamedTempFile](tempfile_3::NamedTempFile)
+//! as above. It is possible to get the best of both worlds as shown in the example.
+//! ```rust,no_run
+#![doc = include_str!("../examples/utoipa/src/main.rs")]
+//! ```
+//!
 //! ### Validation
 //!
 //! In order to perform validation on the various attributes of a field, I would recommend using

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,9 +261,8 @@
 //! Note: File uploads in `utoipa` require a type of `Vec<u8>` which is incompatible with
 //! `axum_typed_multipart` which uses either `Bytes` or [tempfile::NamedTempFile](tempfile_3::NamedTempFile)
 //! as above. It is possible to get the best of both worlds as shown in the example.
-//! ```rust,no_run
-#![doc = include_str!("../examples/utoipa/src/main.rs")]
-//! ```
+//!
+//! The example can be found in the [example directory](https://github.com/murar8/axum_typed_multipart/tree/main/examples/utoipa)
 //!
 //! ### Validation
 //!


### PR DESCRIPTION
As per #82 I've added a minimal example of using `axum_typed_multipart` with `utoipa`

The example is self-contained and I included a `Cargo.toml` because it requires additional dependencies. I haven't included a README as the code is hopefully reasonably easy to follow. On starting the web server a `rapidoc` user interface will describe the API endpoint and present a sample form that can be filled.

Thanks