### PR TITLE
fix(macros): emit fully-qualified paths in derive output

### DIFF
--- a/macros/src/impls/try_from_field.rs
+++ b/macros/src/impls/try_from_field.rs
@@ -56,22 +56,22 @@ pub fn macro_impl(input: TokenStream) -> TokenStream {
         let f_ident = &f.ident;
         let strlit = Lit::Str(LitStr::new(&name, f_ident.span()));
         quote! {
-            #strlit => Ok(Self::#f_ident)
+            #strlit => ::core::result::Result::Ok(Self::#f_ident)
         }
     });
 
     let res = quote! {
-        #[axum_typed_multipart::async_trait]
+        #[::axum_typed_multipart::async_trait]
         impl ::axum_typed_multipart::TryFromField for #ident {
             async fn try_from_field(
                 field: ::axum::extract::multipart::Field<'_>,
                 limit_bytes: ::core::option::Option<usize>,
             ) -> ::core::result::Result<Self, ::axum_typed_multipart::TypedMultipartError> {
-                let field_name = field.name().unwrap_or_default().to_string();
-                let value: String = ::axum_typed_multipart::TryFromField::try_from_field(field, limit_bytes).await?;
+                let field_name = <::std::string::String as ::core::convert::From<&str>>::from(field.name().unwrap_or_default());
+                let value: ::std::string::String = ::axum_typed_multipart::TryFromField::try_from_field(field, limit_bytes).await?;
                 match value.as_str() {
                     #(#match_arms),*,
-                    _ => Err(::axum_typed_multipart::TypedMultipartError::InvalidEnumValue {
+                    _ => ::core::result::Result::Err(::axum_typed_multipart::TypedMultipartError::InvalidEnumValue {
                         field_name,
                         value,
                     })

--- a/macros/src/impls/try_from_multipart.rs
+++ b/macros/src/impls/try_from_multipart.rs
@@ -71,11 +71,11 @@ pub fn macro_impl(input: TokenStream) -> TokenStream {
 
     let declarations = fields.iter().map(|FieldData { ident, ty, .. }| {
         if matches_vec_signature(ty) {
-            quote! { let mut #ident: #ty = std::vec::Vec::new(); }
+            quote! { let mut #ident: #ty = ::std::vec::Vec::new(); }
         } else if matches_option_signature(ty) {
-            quote! { let mut #ident: #ty = std::option::Option::None; }
+            quote! { let mut #ident: #ty = ::core::option::Option::None; }
         } else {
-            quote! { let mut #ident: std::option::Option<#ty> = std::option::Option::None; }
+            quote! { let mut #ident: ::core::option::Option<#ty> = ::core::option::Option::None; }
         }
     });
 
@@ -84,7 +84,7 @@ pub fn macro_impl(input: TokenStream) -> TokenStream {
         .map(|field @ FieldData { ident, ty, limit, .. }| {
             let name = field.name(rename_all);
             let value = quote! {
-                <_ as axum_typed_multipart::TryFromFieldWithState<_>>::try_from_field_with_state(__field__, #limit, state).await?
+                <_ as ::axum_typed_multipart::TryFromFieldWithState<_>>::try_from_field_with_state(__field__, #limit, state).await?
             };
 
             let assignment = if matches_vec_signature(ty) {
@@ -92,17 +92,17 @@ pub fn macro_impl(input: TokenStream) -> TokenStream {
             } else if strict {
                 quote! {
                     if #ident.is_none() {
-                        #ident = Some(#value);
+                        #ident = ::core::option::Option::Some(#value);
                     } else {
-                        return Err(
-                            axum_typed_multipart::TypedMultipartError::DuplicateField {
-                                field_name: String::from(#name)
+                        return ::core::result::Result::Err(
+                            ::axum_typed_multipart::TypedMultipartError::DuplicateField {
+                                field_name: <::std::string::String as ::core::convert::From<&str>>::from(#name)
                             }
                         );
                     }
                 }
             } else {
-                quote! { #ident = Some(#value); }
+                quote! { #ident = ::core::option::Option::Some(#value); }
             };
 
             quote! {
@@ -116,8 +116,8 @@ pub fn macro_impl(input: TokenStream) -> TokenStream {
     if strict {
         assignments.push(quote! {
             {
-                return Err(
-                    axum_typed_multipart::TypedMultipartError::UnknownField {
+                return ::core::result::Result::Err(
+                    ::axum_typed_multipart::TypedMultipartError::UnknownField {
                         field_name: __field_name__
                     }
                 );
@@ -131,7 +131,7 @@ pub fn macro_impl(input: TokenStream) -> TokenStream {
     let default_fields = required_fields.clone().filter(|FieldData { default, .. }| *default);
     let default_assignments = default_fields.map(|FieldData { ident, ty, .. }| {
         quote! {
-            let #ident: Option<#ty> = #ident.or_else(|| Some(#ty::default()));
+            let #ident: ::core::option::Option<#ty> = #ident.or_else(|| ::core::option::Option::Some(<#ty as ::core::default::Default>::default()));
         }
     });
 
@@ -139,8 +139,8 @@ pub fn macro_impl(input: TokenStream) -> TokenStream {
         let field_name = field.name(rename_all);
         quote! {
             let #ident = #ident.ok_or(
-                axum_typed_multipart::TypedMultipartError::MissingField {
-                    field_name: String::from(#field_name)
+                ::axum_typed_multipart::TypedMultipartError::MissingField {
+                    field_name: <::std::string::String as ::core::convert::From<&str>>::from(#field_name)
                 }
             )?;
         }
@@ -149,25 +149,25 @@ pub fn macro_impl(input: TokenStream) -> TokenStream {
     let idents = fields.iter().map(|FieldData { ident, .. }| ident);
 
     let missing_field_name_fallback = if strict {
-        quote! { return Err(axum_typed_multipart::TypedMultipartError::NamelessField) }
+        quote! { return ::core::result::Result::Err(::axum_typed_multipart::TypedMultipartError::NamelessField) }
     } else {
         quote! { continue }
     };
 
-    let generic = state.is_none().then(|| quote! { <S: Sync> });
+    let generic = state.is_none().then(|| quote! { <S: ::core::marker::Sync> });
     let state = state.map(|state| quote! { #state }).unwrap_or(quote! { S });
 
     let output = quote! {
-        #[axum_typed_multipart::async_trait]
-        impl #generic axum_typed_multipart::TryFromMultipartWithState<#state> for #ident {
-            async fn try_from_multipart_with_state(multipart: &mut axum::extract::multipart::Multipart, state: &#state) -> Result<Self, axum_typed_multipart::TypedMultipartError> {
+        #[::axum_typed_multipart::async_trait]
+        impl #generic ::axum_typed_multipart::TryFromMultipartWithState<#state> for #ident {
+            async fn try_from_multipart_with_state(multipart: &mut ::axum::extract::multipart::Multipart, state: &#state) -> ::core::result::Result<Self, ::axum_typed_multipart::TypedMultipartError> {
                 #(#declarations)*
 
-                while let Some(__field__) = multipart.next_field().await? {
+                while let ::core::option::Option::Some(__field__) = multipart.next_field().await? {
                     let __field_name__ = match __field__.name() {
-                        | Some("")
-                        | None => #missing_field_name_fallback,
-                        | Some(name) => name.to_string(),
+                        | ::core::option::Option::Some("")
+                        | ::core::option::Option::None => #missing_field_name_fallback,
+                        | ::core::option::Option::Some(name) => <::std::string::String as ::core::convert::From<&str>>::from(name),
                     };
 
                     #(#assignments) else *
@@ -177,7 +177,7 @@ pub fn macro_impl(input: TokenStream) -> TokenStream {
 
                 #(#checks)*
 
-                Ok(Self { #(#idents),* })
+                ::core::result::Result::Ok(Self { #(#idents),* })
             }
         }
     };

--- a/macros/src/limit_bytes.rs
+++ b/macros/src/limit_bytes.rs
@@ -21,10 +21,10 @@ impl darling::FromMeta for LimitBytes {
 impl ToTokens for LimitBytes {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         tokens.extend(match self.0 {
-            None => quote! { None },
+            None => quote! { ::core::option::Option::None },
             Some(b) => {
                 let n = b.as_u64() as usize;
-                quote! { Some(#n) }
+                quote! { ::core::option::Option::Some(#n) }
             }
         });
     }

--- a/macros/tests/test_hygiene.rs
+++ b/macros/tests/test_hygiene.rs
@@ -11,9 +11,7 @@
 
 // `#[async_trait]` (third-party) requires these in scope; our own macros
 // must not require anything beyond what they qualify themselves.
-extern crate alloc as __alloc;
-use ::core::option::Option::None;
-use __alloc::boxed::Box;
+use ::std::boxed::Box;
 
 #[derive(::axum_typed_multipart::TryFromMultipart)]
 struct Lax {
@@ -30,6 +28,21 @@ struct Strict {
     name: ::std::string::String,
     tags: ::std::vec::Vec<::std::string::String>,
     opt: ::core::option::Option<::std::string::String>,
+}
+
+#[derive(::axum_typed_multipart::TryFromMultipart)]
+struct WithLimitsAndFieldData {
+    #[form_data(limit = "1KB", field_name = "renamed")]
+    blob: ::std::vec::Vec<u8>,
+    file: ::axum_typed_multipart::FieldData<::axum::body::Bytes>,
+}
+
+struct MyState;
+
+#[derive(::axum_typed_multipart::TryFromMultipart)]
+#[try_from_multipart(state = MyState, strict)]
+struct WithState {
+    name: ::std::string::String,
 }
 
 #[derive(::axum_typed_multipart::TryFromField)]

--- a/macros/tests/test_hygiene.rs
+++ b/macros/tests/test_hygiene.rs
@@ -1,0 +1,47 @@
+//! Verifies that the derive macros emit fully-qualified paths and do not
+//! depend on the prelude or on any specific names being in scope.
+//!
+//! `#![no_implicit_prelude]` disables the Rust prelude, so any unqualified
+//! reference in the macro output (e.g. `Some`, `Result`, `String`, `Vec`)
+//! will fail to compile.
+
+#![no_implicit_prelude]
+#![allow(dead_code)]
+#![cfg_attr(all(coverage_nightly, test), feature(coverage_attribute))]
+
+// `#[async_trait]` (third-party) requires these in scope; our own macros
+// must not require anything beyond what they qualify themselves.
+extern crate alloc as __alloc;
+use ::core::option::Option::None;
+use __alloc::boxed::Box;
+
+#[derive(::axum_typed_multipart::TryFromMultipart)]
+struct Lax {
+    name: ::std::string::String,
+    tags: ::std::vec::Vec<::std::string::String>,
+    opt: ::core::option::Option<::std::string::String>,
+    #[form_data(default)]
+    def: ::std::string::String,
+}
+
+#[derive(::axum_typed_multipart::TryFromMultipart)]
+#[try_from_multipart(strict)]
+struct Strict {
+    name: ::std::string::String,
+    tags: ::std::vec::Vec<::std::string::String>,
+    opt: ::core::option::Option<::std::string::String>,
+}
+
+#[derive(::axum_typed_multipart::TryFromField)]
+enum Plain {
+    A,
+    B,
+}
+
+#[derive(::axum_typed_multipart::TryFromField)]
+#[try_from_field(rename_all = "snake_case")]
+enum Renamed {
+    #[field(rename = "x")]
+    First,
+    Second,
+}


### PR DESCRIPTION
## Summary
- Fully qualify every path emitted by the `TryFromMultipart` and `TryFromField` derives — `Option`/`Some`/`None`, `Result`/`Ok`/`Err`, `String`, `Vec`, `Sync`, plus all references to `axum_typed_multipart` and `axum`.
- Route `String::from` and `T::default()` through UFCS so the generated code doesn't require `From`/`Default` in scope.
- Add `macros/tests/test_hygiene.rs`: a `#![no_implicit_prelude]` test that derives both macros across lax/strict/default/enum/rename variants — locks the hygiene contract in at compile time.

Closes #125. Supersedes #126.

## Test plan
- [x] `cargo test --workspace --all-features --all-targets`
- [x] `cargo clippy --workspace --all-features --all-targets -- -Dwarnings -Dclippy::all`
- [x] `cargo fmt --all`
- [x] New `test_hygiene` test compiles (and would fail without these fixes)